### PR TITLE
Add more extensibility to AWS Batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
+dist: xenial
 language: python
 python:
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
-before_install:
-  - sudo apt-get autoremove sqlite3
-  - sudo apt-get install python-software-properties
-  - sudo apt-add-repository -y ppa:travis-ci/sqlite3
-  - sudo apt-get -y update
-  - sudo apt-cache show sqlite3
-  - sudo apt-get install sqlite3=3.7.15.1-1~travis1
+services:
+  - postgresql
 install:
-  - pip install apache-airflow boto3 pylint isort marshmallow
+  - pip install apache-airflow[postgres] boto3 pylint isort marshmallow
 env:
-  - AIRFLOW__BATCH__REGION=us-west-1 AIRFLOW__BATCH__JOB_NAME=some-job-name AIRFLOW__BATCH__JOB_QUEUE=some-job-queue AIRFLOW__BATCH__JOB_DEFINITION=some-job-def AIRFLOW__ECS_FARGATE__REGION=us-west-1 AIRFLOW__ECS_FARGATE__CLUSTER=some-cluster AIRFLOW__ECS_FARGATE__CONTAINER_NAME=some-container-name AIRFLOW__ECS_FARGATE__TASK_DEFINITION=some-task-def AIRFLOW__ECS_FARGATE__LAUNCH_TYPE=FARGATE AIRFLOW__ECS_FARGATE__PLATFORM_VERSION=LATEST AIRFLOW__ECS_FARGATE__ASSIGN_PUBLIC_IP=DISABLED AIRFLOW__ECS_FARGATE__SECURITY_GROUPS=SG1,SG2 AIRFLOW__ECS_FARGATE__SUBNETS=SUB1,SUB2
+  - AIRFLOW__BATCH__REGION=us-west-1 AIRFLOW__BATCH__JOB_NAME=some-job-name AIRFLOW__BATCH__JOB_QUEUE=some-job-queue AIRFLOW__BATCH__JOB_DEFINITION=some-job-def AIRFLOW__ECS_FARGATE__REGION=us-west-1 AIRFLOW__ECS_FARGATE__CLUSTER=some-cluster AIRFLOW__ECS_FARGATE__CONTAINER_NAME=some-container-name AIRFLOW__ECS_FARGATE__TASK_DEFINITION=some-task-def AIRFLOW__ECS_FARGATE__LAUNCH_TYPE=FARGATE AIRFLOW__ECS_FARGATE__PLATFORM_VERSION=LATEST AIRFLOW__ECS_FARGATE__ASSIGN_PUBLIC_IP=DISABLED AIRFLOW__ECS_FARGATE__SECURITY_GROUPS=SG1,SG2 AIRFLOW__ECS_FARGATE__SUBNETS=SUB1,SUB2 AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://postgres:@localhost:5432/airflow
+before_script:
+  - psql -c 'create database airflow;' -U postgres
+  - airflow initdb
 script:
   - pylint --fail-under=9 ./airflow_aws_executors
   - isort -c -rc ./airflow_aws_executors

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
+addons:
+  apt_packages:
+    - sqlite3
+    - libsqlite3-dev
 install:
   - pip install apache-airflow boto3 pylint isort marshmallow
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,16 @@ python:
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
-services:
-  - postgresql
+before_install:
+  - sudo apt-get autoremove sqlite3
+  - sudo apt-get install python-software-properties
+  - sudo apt-add-repository -y ppa:linuxgndu/sqlite-nightly
+  - sudo apt-get -y update
+  - sudo apt-cache show sqlite3
 install:
-  - pip install apache-airflow[postgres] boto3 pylint isort marshmallow
+  - pip install apache-airflow boto3 pylint isort marshmallow
 env:
-  - AIRFLOW__BATCH__REGION=us-west-1 AIRFLOW__BATCH__JOB_NAME=some-job-name AIRFLOW__BATCH__JOB_QUEUE=some-job-queue AIRFLOW__BATCH__JOB_DEFINITION=some-job-def AIRFLOW__ECS_FARGATE__REGION=us-west-1 AIRFLOW__ECS_FARGATE__CLUSTER=some-cluster AIRFLOW__ECS_FARGATE__CONTAINER_NAME=some-container-name AIRFLOW__ECS_FARGATE__TASK_DEFINITION=some-task-def AIRFLOW__ECS_FARGATE__LAUNCH_TYPE=FARGATE AIRFLOW__ECS_FARGATE__PLATFORM_VERSION=LATEST AIRFLOW__ECS_FARGATE__ASSIGN_PUBLIC_IP=DISABLED AIRFLOW__ECS_FARGATE__SECURITY_GROUPS=SG1,SG2 AIRFLOW__ECS_FARGATE__SUBNETS=SUB1,SUB2 AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://postgres:@localhost:5432/airflow
-before_script:
-  - psql -c 'create database airflow;' -U postgres
-  - airflow initdb
+  - AIRFLOW__BATCH__REGION=us-west-1 AIRFLOW__BATCH__JOB_NAME=some-job-name AIRFLOW__BATCH__JOB_QUEUE=some-job-queue AIRFLOW__BATCH__JOB_DEFINITION=some-job-def AIRFLOW__ECS_FARGATE__REGION=us-west-1 AIRFLOW__ECS_FARGATE__CLUSTER=some-cluster AIRFLOW__ECS_FARGATE__CONTAINER_NAME=some-container-name AIRFLOW__ECS_FARGATE__TASK_DEFINITION=some-task-def AIRFLOW__ECS_FARGATE__LAUNCH_TYPE=FARGATE AIRFLOW__ECS_FARGATE__PLATFORM_VERSION=LATEST AIRFLOW__ECS_FARGATE__ASSIGN_PUBLIC_IP=DISABLED AIRFLOW__ECS_FARGATE__SECURITY_GROUPS=SG1,SG2 AIRFLOW__ECS_FARGATE__SUBNETS=SUB1,SUB2
 script:
   - pylint --fail-under=9 ./airflow_aws_executors
   - isort -c -rc ./airflow_aws_executors

--- a/airflow_aws_executors/batch_executor.py
+++ b/airflow_aws_executors/batch_executor.py
@@ -124,17 +124,20 @@ class AwsBatchExecutor(BaseExecutor):
         """
         if executor_config and 'command' in executor_config:
             raise ValueError('Executor Config should never override "command"')
-        job_id = self._submit_job(command, executor_config or {})
+        job_id = self._submit_job(key, command, queue, executor_config or {})
         self.active_workers.add_job(job_id, key)
 
-    def _submit_job(self, cmd: CommandType, exec_config: ExecutorConfigType) -> str:
+    def _submit_job(
+        self, 
+        key: TaskInstanceKeyType,
+        cmd: CommandType, queue: str,
+        exec_config: ExecutorConfigType
+    ) -> str:
         """
         The command and executor config will be placed in the container-override section of the JSON request, before
-        calling Boto3's "run_task" function.
+        calling Boto3's "submit_job" function.
         """
-        submit_job_api = deepcopy(self.submit_job_kwargs)
-        submit_job_api['containerOverrides'].update(exec_config)
-        submit_job_api['containerOverrides']['command'] = cmd
+        submit_job_api = self._submit_job_kwargs(key, cmd, queue, exec_config)
         boto_run_task = self.batch.submit_job(**submit_job_api)
         try:
             submit_job_response = BatchSubmitJobResponseSchema().load(boto_run_task)
@@ -147,6 +150,25 @@ class AwsBatchExecutor(BaseExecutor):
                 )
             )
         return submit_job_response['job_id']
+
+    def _submit_job_kwargs(
+        self,
+        key: TaskInstanceKeyType,
+        cmd: CommandType,
+        queue: str, exec_config: ExecutorConfigType
+    ) -> dict:
+        """
+        This modifies the standard kwargs to be specific to this task by overriding the airflow command and updating
+        the container overrides.
+
+        One last chance to modify Boto3's "submit_job" kwarg params before it gets passed into the Boto3 client.
+        For the latest kwarg parameters:
+        .. seealso:: https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html
+        """
+        submit_job_api = deepcopy(self.submit_job_kwargs)
+        submit_job_api['containerOverrides'].update(exec_config)
+        submit_job_api['containerOverrides']['command'] = cmd
+        return submit_job_api
 
     def end(self, heartbeat_interval=10):
         """


### PR DESCRIPTION
Provide full transparency on how AWS Boto3 APIs get called for AWS Batch & AWS Fargate Executors.

- **BATCH:** override _submit_job_kwargs to make modifications to `BATCH_SUBMIT_JOB_KWARGS` at runtime.
- **FARGATE:** override _run_task_kwargs to make modifications to `FARGATE_RUN_TASK_KWARGS` at runtime.