### PR TITLE
Scheduler crashes at EXACTLY 99 tasks.

### DIFF
--- a/airflow_aws_executors/batch_executor.py
+++ b/airflow_aws_executors/batch_executor.py
@@ -101,9 +101,10 @@ class AwsBatchExecutor(BaseExecutor):
 
     def _describe_tasks(self, job_ids) -> List[BatchJob]:
         all_jobs = []
-        max_batch_size = self.__class__.DESCRIBE_JOBS_BATCH_SIZE
-        for i in range((len(job_ids) // max_batch_size) + 1):
-            batched_job_ids = job_ids[i * max_batch_size: (i + 1) * max_batch_size]
+        for i in range(0, len(job_ids), self.__class__.DESCRIBE_JOBS_BATCH_SIZE):
+            batched_job_ids = job_ids[i: i + self.__class__.DESCRIBE_JOBS_BATCH_SIZE]
+            if not batched_job_ids:
+                continue
             boto_describe_tasks = self.batch.describe_jobs(jobs=batched_job_ids)
             try:
                 describe_tasks_response = BatchDescribeJobsResponseSchema().load(boto_describe_tasks)

--- a/airflow_aws_executors/ecs_fargate_executor.py
+++ b/airflow_aws_executors/ecs_fargate_executor.py
@@ -144,8 +144,10 @@ class AwsEcsFargateExecutor(BaseExecutor):
 
     def __describe_tasks(self, task_arns):
         all_task_descriptions = {'tasks': [], 'failures': []}
-        for i in range((len(task_arns) // self.DESCRIBE_TASKS_BATCH_SIZE) + 1):
-            batched_task_arns = task_arns[i * self.DESCRIBE_TASKS_BATCH_SIZE: (i + 1) * self.DESCRIBE_TASKS_BATCH_SIZE]
+        for i in range(0, len(task_arns), self.DESCRIBE_TASKS_BATCH_SIZE):
+            batched_task_arns = task_arns[i: i + self.DESCRIBE_TASKS_BATCH_SIZE]
+            if not batched_task_arns:
+                continue
             boto_describe_tasks = self.ecs.describe_tasks(tasks=batched_task_arns, cluster=self.cluster)
             try:
                 describe_tasks_response = BotoDescribeTasksSchema().load(boto_describe_tasks)


### PR DESCRIPTION
What happens if there are EXACTLY 99 task ids? Well, the first boto3 call will schedule tasks 0-100. The second call will schedule 100-100. But 100-100 is actually just an empty list, so boto3 freaks out & the scheduler crashes... Gross